### PR TITLE
Add clusterorder delete command

### DIFF
--- a/internal/cmd/delete/clusterorder/delete_clusterorder_cmd.go
+++ b/internal/cmd/delete/clusterorder/delete_clusterorder_cmd.go
@@ -1,0 +1,90 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package clusterorder
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	fulfillmentv1 "github.com/innabox/fulfillment-cli/internal/api/fulfillment/v1"
+	"github.com/innabox/fulfillment-cli/internal/config"
+)
+
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:     "clusterorder [flags] ID",
+		Aliases: []string{"clusterorders"},
+		Short:   "Delete a cluster order",
+		RunE:    runner.run,
+	}
+	return result
+}
+
+type runnerContext struct {
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+        // Check that there is exactly one cluster order ID specified
+        if len(args) != 1 {
+	        fmt.Fprintf(
+                        os.Stderr,
+                        "Expected exactly one cluster order ID\n",
+	        )
+                os.Exit(1)
+        }
+	orderId := args[0]
+
+	// Get the context:
+	ctx := cmd.Context()
+
+	// Get the configuration:
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	if cfg.Address == "" {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	// Create the gRPC connection from the configuration:
+	conn, err := cfg.Connect()
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+
+	// Create the client for the cluster orders service:
+	client := fulfillmentv1.NewClusterOrdersClient(conn)
+
+	// Get the order:
+	_, err = client.Get(ctx, &fulfillmentv1.ClusterOrdersGetRequest{
+		Id: orderId,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to retrieve order: %w", err)
+	}
+
+	// Delete the order:
+	_, err = client.Delete(ctx, &fulfillmentv1.ClusterOrdersDeleteRequest{
+		Id: orderId,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete order: %w", err)
+	}
+	fmt.Printf("Deleted cluster order '%s''\n", orderId)
+
+	return nil
+}

--- a/internal/cmd/delete/delete_cmd.go
+++ b/internal/cmd/delete/delete_cmd.go
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package delete
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/innabox/fulfillment-cli/internal/cmd/delete/clusterorder"
+)
+
+func Cmd() *cobra.Command {
+	result := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete resource",
+	}
+	result.AddCommand(clusterorder.Cmd())
+	return result
+}

--- a/internal/cmd/root_cmd.go
+++ b/internal/cmd/root_cmd.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/innabox/fulfillment-cli/internal/cmd/create"
+	"github.com/innabox/fulfillment-cli/internal/cmd/delete"
 	"github.com/innabox/fulfillment-cli/internal/cmd/describe"
 	"github.com/innabox/fulfillment-cli/internal/cmd/get"
 	"github.com/innabox/fulfillment-cli/internal/cmd/getkubeconfig"
@@ -32,6 +33,7 @@ func Root() *cobra.Command {
 		SilenceErrors: true,
 	}
 	result.AddCommand(create.Cmd())
+	result.AddCommand(delete.Cmd())
 	result.AddCommand(describe.Cmd())
 	result.AddCommand(get.Cmd())
 	result.AddCommand(getkubeconfig.Cmd())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a CLI command to delete a cluster order by providing its unique identifier.
  - Integrated deletion functionality into the main command interface with clear error and confirmation messages for user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->