### PR TITLE
Allow release job to publish artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5


### PR DESCRIPTION
A previous patch added a job to create releases and publish the artifacts, but that job is failing because the required permissions are disabled by default in this repository. To fix that this patch explicitly adds the required permissions to the job.