### PR TITLE
Add `DELETED` column to cluster orders

### DIFF
--- a/internal/cmd/get/tables/clusterorder.yaml
+++ b/internal/cmd/get/tables/clusterorder.yaml
@@ -17,6 +17,9 @@ columns:
 - header: ID
   value: id
 
+- header: DELETED
+  value: "has(metadata.deletion_timestamp)? string(metadata.deletion_timestamp): '-'"
+
 - header: TEMPLATE
   value: spec.template_id
 


### PR DESCRIPTION
This patch adds a new `DELETED` column to the cluster orders table. It shows the deletion timestamp, or only a dash if that is zero:

```
$ ./fulfillment-cli get clusterorders
ID                                    DELETED                      TEMPLATE        STATE        CLUSTER
144b1b0a-5324-496f-a540-7865642758b5  2025-05-06T10:02:42.810524Z  ocp_4_17_small  UNSPECIFIED
24ac69b3-0ca2-4ea2-84a0-83ff756a788e  -                            ocp_4_17_small  UNSPECIFIED
```