### PR TITLE
Update to Go 1.24

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -12,25 +12,25 @@
 # the License.
 #
 
-name: Release
-
-on:
-  push:
-    tags:
-    - '*'
-
-jobs:
-
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ./.github/actions/setup-go
-    - uses: goreleaser/goreleaser-action@v6
-      with:
-        args: release --clean
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+name: Setup Go
+description: Install and Go and Ginkgo
+runs:
+  using: composite
+  steps:
+  - uses: actions/setup-go@v5
+    with:
+      go-version: '1.24.4'
+  - shell: bash
+    run: |
+      go mod download
+  - id: ginkgo-cache
+    uses: actions/cache@v4
+    with:
+      key: ginkgo
+      path: ~/go/bin/ginkgo
+  - if: steps.ginkgo-cache.outputs.cache-hit != 'true'
+    shell: bash
+    run: |
+      module="github.com/onsi/ginkgo/v2"
+      version=$(go list -f '{{ .Version }}' -m "${module}")
+      go install "${module}/ginkgo@${version}"

--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -34,9 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
-      with:
-        go-version: '1.22.9'
+    - uses: ./.github/actions/setup-go
     - run: |
         gofmt -s -l -w .
         git diff --exit-code
@@ -59,13 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
-      with:
-        go-version: '1.22.9'
+    - uses: ./.github/actions/setup-go
     - run: |
-        module="github.com/onsi/ginkgo/v2"
-        version=$(go list -f '{{ .Version }}' -m "${module}")
-        go install "${module}/ginkgo@${version}"
         ginkgo run -r
 
   build-binary:
@@ -73,8 +66,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
-      with:
-        go-version: '1.22.9'
+    - uses: ./.github/actions/setup-go
     - run: |
         go build

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/innabox/fulfillment-cli
 
-go 1.23.0
-
-toolchain go1.23.5
+go 1.24.5
 
 require (
 	github.com/gertd/go-pluralize v0.2.1


### PR DESCRIPTION
We are currently using Go 1.22, which is no longer support. This patch updates to Go 1.24.

In order to reduce the number of places where the version is specified the patch also adds the same `setup-go` GitHub action that is used in the `fulfillment-service` project.