### PR TITLE
Add gRPC client logging interceptor

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,6 +172,19 @@ func (c *Config) Connect(ctx context.Context) (result *grpc.ClientConn, err erro
 		dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(token))
 	}
 
+	// Add the logging interceptor:
+	loggingInterceptor, err := logging.NewInterceptor().
+		SetLogger(logger).
+		Build()
+	if err != nil {
+		return
+	}
+	dialOpts = append(
+		dialOpts,
+		grpc.WithUnaryInterceptor(loggingInterceptor.UnaryClient),
+		grpc.WithStreamInterceptor(loggingInterceptor.StreamClient),
+	)
+
 	result, err = grpc.NewClient(c.Address, dialOpts...)
 	return
 }

--- a/internal/logging/logging_interceptor.go
+++ b/internal/logging/logging_interceptor.go
@@ -1,0 +1,668 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	grpcpeer "google.golang.org/grpc/peer"
+	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// InterceptorBuilder contains the data and logic needed to build an interceptor that writes to the log the details of
+// calls. Don't create instances of this type directly, use the NewInterceptor function instead.
+type InterceptorBuilder struct {
+	logger  *slog.Logger
+	headers bool
+	bodies  bool
+	redact  bool
+	flags   *pflag.FlagSet
+}
+
+// Interceptor contains the data needed by the Interceptor, like the logger and settings.
+type Interceptor struct {
+	logger  *slog.Logger
+	headers bool
+	bodies  bool
+	redact  bool
+}
+
+// NewInterceptor creates a builder that can then be used to configure and create a logging interceptor.
+func NewInterceptor() *InterceptorBuilder {
+	return &InterceptorBuilder{
+		redact: true,
+	}
+}
+
+// SetLogger sets the logger that will be used to write to the log. This is mandatory.
+func (b *InterceptorBuilder) SetLogger(value *slog.Logger) *InterceptorBuilder {
+	b.logger = value
+	return b
+}
+
+// SetHeaders indicates if headers should be included in log messages. The default is to not include them.
+func (b *InterceptorBuilder) SetHeaders(value bool) *InterceptorBuilder {
+	b.headers = value
+	return b
+}
+
+// SetBodies indicates if details about the request and response bodies should be included in log messages. The default
+// is to not include them.
+func (b *InterceptorBuilder) SetBodies(value bool) *InterceptorBuilder {
+	b.bodies = value
+	return b
+}
+
+// SetRedact indicates if security sensitive information should be redacted. The default is true.
+func (b *InterceptorBuilder) SetRedact(value bool) *InterceptorBuilder {
+	b.redact = value
+	return b
+}
+
+// SetFlags sets the command line flags that should be used to configure the interceptor. This is optional.
+func (b *InterceptorBuilder) SetFlags(flags *pflag.FlagSet) *InterceptorBuilder {
+	b.flags = flags
+	if flags != nil {
+		if flags.Changed(headersFlagName) {
+			value, err := flags.GetBool(headersFlagName)
+			if err == nil {
+				b.SetHeaders(value)
+			}
+		}
+		if flags.Changed(bodiesFlagName) {
+			value, err := flags.GetBool(bodiesFlagName)
+			if err == nil {
+				b.SetBodies(value)
+			}
+		}
+	}
+	return b
+}
+
+// Build uses the data stored in the builder to create and configure a new interceptor.
+func (b *InterceptorBuilder) Build() (result *Interceptor, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+
+	// Create and populate the object:
+	result = &Interceptor{
+		logger:  b.logger,
+		headers: b.headers,
+		bodies:  b.bodies,
+		redact:  b.redact,
+	}
+	return
+}
+
+// UnaryServer is the unary server interceptor function.
+func (i *Interceptor) UnaryServer(ctx context.Context, request any, info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler) (response any, err error) {
+	// Ignore reflection calls:
+	if i.isReflectionMethod(info.FullMethod) {
+		response, err = handler(ctx, request)
+		return
+	}
+
+	// The processing here is expensive, so better if we avoid it completely when debug is disabled:
+	if !i.logger.Enabled(ctx, slog.LevelDebug) {
+		response, err = handler(ctx, request)
+		return
+	}
+
+	// Get the time before calling the handler so that we can later compute the duration of the call:
+	timeBefore := time.Now()
+
+	// Write the details of the request:
+	methodField := slog.String("method", info.FullMethod)
+	requestFields := []any{
+		methodField,
+	}
+	peerInfo, ok := grpcpeer.FromContext(ctx)
+	if ok {
+		peerAddr := peerInfo.Addr
+		if peerAddr != nil {
+			peerAddrField := slog.String("address", peerAddr.String())
+			requestFields = append(requestFields, peerAddrField)
+		}
+	}
+	if i.headers {
+		md, ok := metadata.FromIncomingContext(ctx)
+		if ok {
+			if i.redact {
+				md = i.redactMD(md)
+			}
+			mdField := slog.Any("metadata", md)
+			requestFields = append(requestFields, mdField)
+		}
+	}
+	if i.bodies && request != nil {
+		bodyField, ok := i.dumpMessage(ctx, "request", request)
+		if ok {
+			requestFields = append(requestFields, bodyField)
+		}
+	}
+	i.logger.DebugContext(ctx, "Received unary request", requestFields...)
+
+	// Call the handler:
+	response, err = handler(ctx, request)
+
+	// Write the details of the response:
+	timeElapsed := time.Since(timeBefore)
+	timeField := slog.Duration("duration", timeElapsed)
+	codeField := slog.String("code", grpcstatus.Code(err).String())
+	responseFields := []any{
+		methodField,
+		timeField,
+		codeField,
+	}
+	if i.bodies && response != nil {
+		bodyField, ok := i.dumpMessage(ctx, "response", response)
+		if ok {
+			responseFields = append(responseFields, bodyField)
+		}
+	}
+	if err != nil {
+		errField := slog.Any("error", err)
+		responseFields = append(responseFields, errField)
+	}
+	i.logger.DebugContext(ctx, "Sent unary response", responseFields...)
+
+	return
+}
+
+// StreamServer is the stream server interceptor function.
+func (i *Interceptor) StreamServer(server any, stream grpc.ServerStream, info *grpc.StreamServerInfo,
+	handler grpc.StreamHandler) error {
+	// Ignore reflection calls:
+	if i.isReflectionMethod(info.FullMethod) {
+		return handler(server, stream)
+	}
+
+	// The processing here is expensive, so better if we avoid it completely when debug is disabled:
+	ctx := stream.Context()
+	if !i.logger.Enabled(ctx, slog.LevelDebug) {
+		return handler(server, stream)
+	}
+
+	// Get the time before calling the handler so that we can later compute the duration of the call:
+	timeBefore := time.Now()
+
+	// Write the details of the request:
+	methodField := slog.String("method", info.FullMethod)
+	requestFields := []any{
+		methodField,
+	}
+	peerInfo, ok := grpcpeer.FromContext(ctx)
+	if ok {
+		peerAddr := peerInfo.Addr
+		if peerAddr != nil {
+			peerAddrField := slog.String("address", peerAddr.String())
+			requestFields = append(requestFields, peerAddrField)
+		}
+	}
+	if i.headers {
+		md, ok := metadata.FromIncomingContext(ctx)
+		if ok {
+			if i.redact {
+				md = i.redactMD(md)
+			}
+			mdField := slog.Any("metadata", md)
+			requestFields = append(requestFields, mdField)
+		}
+	}
+	i.logger.DebugContext(ctx, "Received stream start request", requestFields...)
+
+	// Wrap the stream so that we can log the details of the messages exchanged:
+	stream = &interceptorServerStream{
+		parent: i,
+		logger: i.logger,
+		stream: stream,
+	}
+	err := handler(server, stream)
+
+	// Write the details of the response:
+	timeElapsed := time.Since(timeBefore)
+	timeField := slog.Duration("duration", timeElapsed)
+	responseFields := []any{
+		methodField,
+		timeField,
+	}
+	if err != nil {
+		errField := slog.Any("error", err)
+		responseFields = append(responseFields, errField)
+	}
+	i.logger.DebugContext(ctx, "Sent stream stop response", responseFields...)
+
+	return err
+}
+
+// UnaryClient is the unary client interceptor function.
+func (i *Interceptor) UnaryClient(ctx context.Context, method string, request, response any,
+	conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	// Ignore reflection calls:
+	if i.isReflectionMethod(method) {
+		return invoker(ctx, method, request, response, conn, opts...)
+	}
+
+	// The processing here is expensive, so better if we avoid it completely when debug is disabled:
+	if !i.logger.Enabled(ctx, slog.LevelDebug) {
+		return invoker(ctx, method, request, response, conn, opts...)
+	}
+
+	// Get the time before calling the invoker so that we can later compute the duration of the call:
+	timeBefore := time.Now()
+
+	// Write the details of the request:
+	methodField := slog.String("method", method)
+	targetField := slog.String("target", conn.Target())
+	requestFields := []any{
+		methodField,
+		targetField,
+	}
+	if i.headers {
+		md, ok := metadata.FromOutgoingContext(ctx)
+		if ok {
+			if i.redact {
+				md = i.redactMD(md)
+			}
+			mdField := slog.Any("metadata", md)
+			requestFields = append(requestFields, mdField)
+		}
+	}
+	if i.bodies && request != nil {
+		bodyField, ok := i.dumpMessage(ctx, "request", request)
+		if ok {
+			requestFields = append(requestFields, bodyField)
+		}
+	}
+	i.logger.DebugContext(ctx, "Sending unary request", requestFields...)
+
+	// Call the invoker:
+	err := invoker(ctx, method, request, response, conn, opts...)
+
+	// Write the details of the response:
+	timeElapsed := time.Since(timeBefore)
+	timeField := slog.Duration("duration", timeElapsed)
+	codeField := slog.String("code", grpcstatus.Code(err).String())
+	responseFields := []any{
+		methodField,
+		targetField,
+		timeField,
+		codeField,
+	}
+	if i.bodies && response != nil {
+		bodyField, ok := i.dumpMessage(ctx, "response", response)
+		if ok {
+			responseFields = append(responseFields, bodyField)
+		}
+	}
+	if err != nil {
+		errField := slog.Any("error", err)
+		responseFields = append(responseFields, errField)
+	}
+	i.logger.DebugContext(ctx, "Received unary response", responseFields...)
+
+	return err
+}
+
+// StreamClient is the stream client interceptor function.
+func (i *Interceptor) StreamClient(ctx context.Context, desc *grpc.StreamDesc, conn *grpc.ClientConn, method string,
+	streamer grpc.Streamer, opts ...grpc.CallOption) (stream grpc.ClientStream, err error) {
+	// Ignore reflection calls:
+	if i.isReflectionMethod(method) {
+		return streamer(ctx, desc, conn, method, opts...)
+	}
+
+	// The processing here is expensive, so better if we avoid it completely when debug is disabled:
+	if !i.logger.Enabled(ctx, slog.LevelDebug) {
+		return streamer(ctx, desc, conn, method, opts...)
+	}
+
+	// Wrap the stream so that we can log the details of the messages exchanged:
+	stream, err = streamer(ctx, desc, conn, method, opts...)
+	if err != nil {
+		return
+	}
+	stream = &interceptorClientStream{
+		parent: i,
+		logger: i.logger,
+		stream: stream,
+	}
+	return
+}
+
+func (i *Interceptor) isReflectionMethod(method string) bool {
+	return strings.HasPrefix(method, "/grpc.reflection.")
+}
+
+// redactMetadata generates a copy of the given metadata that doesn't contain security sensitive data, like
+// authentication credentials.
+func (i *Interceptor) redactMD(md metadata.MD) metadata.MD {
+	result := make(metadata.MD)
+	for key, values := range md {
+		redacted := slices.Clone(values)
+		for j, value := range values {
+			redacted[j] = i.redactMDValue(key, value)
+		}
+		result[key] = redacted
+	}
+	return result
+}
+
+func (i *Interceptor) redactMDValue(key string, value string) string {
+	switch key {
+	case "authorization":
+		return i.redactMDAuthorization(value)
+	default:
+		return value
+	}
+}
+
+func (i *Interceptor) redactMDAuthorization(value string) string {
+	position := strings.Index(value, " ")
+	if position == -1 {
+		return redactMark
+	}
+	scheme := value[0:position]
+	return fmt.Sprintf("%s %s", scheme, redactMark)
+}
+
+// dumpMessage tries to covert the given message to something that can be added to the log and returns the corresponding
+// log fields.
+func (i *Interceptor) dumpMessage(ctx context.Context, key string, value any) (field any, ok bool) {
+	switch message := value.(type) {
+	case proto.Message:
+		bytes, err := protojson.Marshal(message)
+		if err != nil {
+			i.logger.ErrorContext(
+				ctx,
+				"Failed to marshal protocol buffers message",
+				slog.Any("error", err),
+			)
+			return
+		}
+		var data any
+		err = json.Unmarshal(bytes, &data)
+		if err != nil {
+			i.logger.ErrorContext(
+				ctx,
+				"Failed to unmarshal protocol buffers message",
+				slog.Any("error", err),
+			)
+			return
+		}
+		ok = true
+		field = slog.Any(key, data)
+	default:
+		i.logger.ErrorContext(
+			ctx,
+			"Failed to dump value because it isn't a protocol buffers message",
+			slog.String("type", fmt.Sprintf("%T", value)),
+		)
+	}
+	return
+}
+
+type interceptorServerStream struct {
+	parent *Interceptor
+	logger *slog.Logger
+	stream grpc.ServerStream
+}
+
+func (s *interceptorServerStream) Context() context.Context {
+	return s.stream.Context()
+}
+
+func (s *interceptorServerStream) SendMsg(message any) error {
+	// Call the stream:
+	err := s.stream.SendMsg(message)
+
+	// Write the details of the sent message:
+	ctx := s.stream.Context()
+	var messageFields []any
+	if s.parent.bodies && message != nil {
+		bodyField, ok := s.parent.dumpMessage(ctx, "message", message)
+		if ok {
+			messageFields = append(messageFields, bodyField)
+		}
+	}
+	if err != nil {
+		errField := slog.Any("error", err)
+		messageFields = append(messageFields, errField)
+	}
+	s.logger.DebugContext(ctx, "Sent stream message", messageFields...)
+
+	return err
+}
+
+func (s *interceptorServerStream) RecvMsg(message any) error {
+	// Return inmediately if this is the end of the stream:
+	err := s.stream.RecvMsg(message)
+	if errors.Is(err, io.EOF) {
+		return err
+	}
+
+	// Write the details of the received message:
+	ctx := s.stream.Context()
+	var messageFields []any
+	if s.parent.bodies && message != nil {
+		bodyField, ok := s.parent.dumpMessage(ctx, "message", message)
+		if ok {
+			messageFields = append(messageFields, bodyField)
+		}
+	}
+	if err != nil {
+		errField := slog.Any("error", err)
+		messageFields = append(messageFields, errField)
+	}
+	s.logger.DebugContext(ctx, "Received stream message", messageFields...)
+
+	return err
+}
+
+func (s *interceptorServerStream) SendHeader(md metadata.MD) error {
+	// Call the stream:
+	err := s.stream.SendHeader(md)
+
+	// Write the details of the sent header:
+	ctx := s.stream.Context()
+	var metadataFields []any
+	if s.parent.headers {
+		if s.parent.redact {
+			md = s.parent.redactMD(md)
+		}
+		mdField := slog.Any("metadata", md)
+		metadataFields = append(metadataFields, mdField)
+	}
+	if err != nil {
+		errField := slog.Any("error", err)
+		metadataFields = append(metadataFields, errField)
+	}
+	s.logger.DebugContext(ctx, "Sent stream header", metadataFields...)
+
+	return err
+}
+
+func (s *interceptorServerStream) SetHeader(md metadata.MD) error {
+	// Call the stream:
+	err := s.stream.SetHeader(md)
+
+	// Write the details of the set header:
+	ctx := s.stream.Context()
+	var metadataFields []any
+	if s.parent.headers {
+		if s.parent.redact {
+			md = s.parent.redactMD(md)
+		}
+		mdField := slog.Any("metadata", md)
+		metadataFields = append(metadataFields, mdField)
+	}
+	if err != nil {
+		errField := slog.Any("error", err)
+		metadataFields = append(metadataFields, errField)
+	}
+	s.logger.DebugContext(ctx, "Set stream header", metadataFields...)
+
+	return err
+}
+
+func (s *interceptorServerStream) SetTrailer(md metadata.MD) {
+	// Call the stream:
+	s.stream.SetTrailer(md)
+
+	// Write the details of the set header:
+	ctx := s.stream.Context()
+	var metadataFields []any
+	if s.parent.headers {
+		if s.parent.redact {
+			md = s.parent.redactMD(md)
+		}
+		mdField := slog.Any("metadata", md)
+		metadataFields = append(metadataFields, mdField)
+	}
+	s.logger.DebugContext(ctx, "Set stream trailer", metadataFields...)
+}
+
+type interceptorClientStream struct {
+	parent *Interceptor
+	logger *slog.Logger
+	stream grpc.ClientStream
+}
+
+func (s *interceptorClientStream) Context() context.Context {
+	return s.stream.Context()
+}
+
+func (s *interceptorClientStream) SendMsg(message any) error {
+	// Call the stream:
+	err := s.stream.SendMsg(message)
+
+	// Write the details of the sent message:
+	ctx := s.stream.Context()
+	var messageFields []any
+	if s.parent.bodies && message != nil {
+		bodyField, ok := s.parent.dumpMessage(ctx, "message", message)
+		if ok {
+			messageFields = append(messageFields, bodyField)
+		}
+	}
+	if err != nil {
+		errField := slog.Any("error", err)
+		messageFields = append(messageFields, errField)
+	}
+	s.logger.DebugContext(ctx, "Sent stream message", messageFields...)
+
+	return err
+}
+
+func (s *interceptorClientStream) RecvMsg(message any) error {
+	// Call the stream:
+	err := s.stream.RecvMsg(message)
+
+	// Check if this is the end of the stream:
+	if errors.Is(err, io.EOF) {
+		return err
+	}
+
+	// Write the details of the received message:
+	ctx := s.stream.Context()
+	var messageFields []any
+	if s.parent.bodies && message != nil {
+		bodyField, ok := s.parent.dumpMessage(ctx, "message", message)
+		if ok {
+			messageFields = append(messageFields, bodyField)
+		}
+	}
+	if err != nil {
+		errField := slog.Any("error", err)
+		messageFields = append(messageFields, errField)
+	}
+	s.logger.DebugContext(ctx, "Received stream message", messageFields...)
+
+	return err
+}
+
+func (s *interceptorClientStream) Header() (metadata.MD, error) {
+	// Call the stream:
+	md, err := s.stream.Header()
+
+	// Write the details of the received header:
+	ctx := s.stream.Context()
+	var metadataFields []any
+	if s.parent.headers {
+		if s.parent.redact {
+			md = s.parent.redactMD(md)
+		}
+		mdField := slog.Any("metadata", md)
+		metadataFields = append(metadataFields, mdField)
+	}
+	if err != nil {
+		errField := slog.Any("error", err)
+		metadataFields = append(metadataFields, errField)
+	}
+	s.logger.DebugContext(ctx, "Received stream header", metadataFields...)
+
+	return md, err
+}
+
+func (s *interceptorClientStream) Trailer() metadata.MD {
+	// Call the stream:
+	md := s.stream.Trailer()
+
+	// Write the details of the received trailer:
+	ctx := s.stream.Context()
+	var metadataFields []any
+	if s.parent.headers {
+		if s.parent.redact {
+			md = s.parent.redactMD(md)
+		}
+		mdField := slog.Any("metadata", md)
+		metadataFields = append(metadataFields, mdField)
+	}
+	s.logger.DebugContext(ctx, "Received stream trailer", metadataFields...)
+
+	return md
+}
+
+func (s *interceptorClientStream) CloseSend() error {
+	// Call the stream:
+	err := s.stream.CloseSend()
+
+	// Write the details of the close send:
+	ctx := s.stream.Context()
+	var closeFields []any
+	if err != nil {
+		errField := slog.Any("error", err)
+		closeFields = append(closeFields, errField)
+	}
+	s.logger.DebugContext(ctx, "Closed send side of stream", closeFields...)
+
+	return err
+}

--- a/internal/logging/logging_interceptor_test.go
+++ b/internal/logging/logging_interceptor_test.go
@@ -1,0 +1,316 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package logging
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	grpccodes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	grpcstatus "google.golang.org/grpc/status"
+
+	testsv1 "github.com/innabox/fulfillment-cli/internal/api/tests/v1"
+)
+
+var _ = Describe("Interceptor", func() {
+	var (
+		ctx         context.Context
+		server      *grpc.Server
+		listener    net.Listener
+		conn        *grpc.ClientConn
+		interceptor *Interceptor
+		buffer      *bytes.Buffer
+		logger      *slog.Logger
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Create the context:
+		ctx = context.Background()
+
+		// Create a buffer for the log output:
+		buffer = &bytes.Buffer{}
+
+		// Create a logger that writes to the buffer:
+		logger, err = NewLogger().
+			SetLevel(slog.LevelDebug.String()).
+			SetOut(buffer).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the interceptor:
+		interceptor, err = NewInterceptor().
+			SetLogger(logger).
+			SetHeaders(true).
+			SetBodies(true).
+			SetRedact(false).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a test server:
+		listener, err = net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).ToNot(HaveOccurred())
+		server = grpc.NewServer()
+		go func() {
+			defer GinkgoRecover()
+			_ = server.Serve(listener)
+		}()
+		DeferCleanup(server.Stop)
+
+		// Create a client connection with interceptor:
+		conn, err = grpc.NewClient(
+			listener.Addr().String(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithUnaryInterceptor(interceptor.UnaryClient),
+			grpc.WithStreamInterceptor(interceptor.StreamClient),
+		)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(conn.Close)
+	})
+
+	Describe("Unary client", func() {
+		It("Logs unary client requests and responses", func() {
+			method := "/test.Service/TestMethod"
+
+			// Mock request and response:
+			request := testsv1.Object_builder{
+				Id:       "my_id",
+				MyString: "my_value",
+			}.Build()
+			response := testsv1.Object_builder{}.Build()
+
+			// Mock invoker that copies request to response:
+			invoker := func(ctx context.Context, method string, request, response any, cc *grpc.ClientConn,
+				options ...grpc.CallOption) error {
+				requestObject := response.(*testsv1.Object)
+				responseObject := request.(*testsv1.Object)
+				requestObject.Id = responseObject.Id
+				requestObject.MyString = responseObject.MyString
+				return nil
+			}
+
+			// Add metadata to context:
+			ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", "Bearer my_token"))
+
+			// Call the interceptor:
+			err := interceptor.UnaryClient(ctx, method, request, response, conn, invoker)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Parse the log messages:
+			messages := Parse(buffer)
+			Expect(messages).To(HaveLen(2))
+
+			// Verify request log:
+			requestMessage := messages[0]
+			Expect(requestMessage["msg"]).To(Equal("Sending unary request"))
+			Expect(requestMessage["method"]).To(Equal(method))
+			Expect(requestMessage["target"]).To(Equal(listener.Addr().String()))
+			Expect(requestMessage["metadata"]).To(HaveKey("authorization"))
+			Expect(requestMessage["request"]).To(HaveKey("myString"))
+
+			// Verify response log:
+			responseMessage := messages[1]
+			Expect(responseMessage["msg"]).To(Equal("Received unary response"))
+			Expect(responseMessage["method"]).To(Equal(method))
+			Expect(responseMessage["target"]).To(Equal(listener.Addr().String()))
+			Expect(responseMessage["code"]).To(Equal("OK"))
+			Expect(responseMessage["response"]).To(HaveKey("myString"))
+		})
+
+		It("Logs errors in unary client calls", func() {
+			method := "/test.Service/TestMethod"
+
+			// Mock request and response:
+			request := &testsv1.Object{}
+			response := &testsv1.Object{}
+
+			// Mock invoker that returns an error:
+			invoker := func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+				return grpcstatus.Error(grpccodes.NotFound, "not found")
+			}
+
+			// Call the interceptor:
+			err := interceptor.UnaryClient(ctx, method, request, response, conn, invoker)
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.NotFound))
+			Expect(status.Message()).To(Equal("not found"))
+
+			// Parse the log messages:
+			messages := Parse(buffer)
+			Expect(messages).To(HaveLen(2))
+
+			// Verify response log contains error:
+			responseMessage := messages[1]
+			Expect(responseMessage["msg"]).To(Equal("Received unary response"))
+			Expect(responseMessage["code"]).To(Equal("NotFound"))
+			Expect(responseMessage["error"]).ToNot(BeNil())
+		})
+
+		It("Skips logging for reflection methods", func() {
+			method := "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo"
+
+			// Mock invoker:
+			invoker := func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+				return nil
+			}
+
+			// Call the interceptor:
+			err := interceptor.UnaryClient(ctx, method, nil, nil, conn, invoker)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Parse the log messages - should be empty:
+			messages := Parse(buffer)
+			Expect(messages).To(BeEmpty())
+		})
+
+		It("Skips logging when debug is disabled", func() {
+			// Create a logger with info level:
+			infoLogger, err := NewLogger().
+				SetLevel(slog.LevelInfo.String()).
+				SetOut(buffer).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create interceptor with info logger:
+			infoInterceptor, err := NewInterceptor().
+				SetLogger(infoLogger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			method := "/test.Service/TestMethod"
+
+			// Mock invoker:
+			invoker := func(ctx context.Context, method string, req, resp any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+				return nil
+			}
+
+			// Call the interceptor:
+			err = infoInterceptor.UnaryClient(ctx, method, nil, nil, conn, invoker)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Parse the log messages - should be empty:
+			messages := Parse(buffer)
+			Expect(messages).To(BeEmpty())
+		})
+	})
+
+	Describe("Stream client", func() {
+		It("Logs stream client start and operations", func() {
+			method := "/test.Service/TestStream"
+			desc := &grpc.StreamDesc{
+				StreamName:    "TestStream",
+				ClientStreams: true,
+				ServerStreams: true,
+			}
+
+			// Mock streamer:
+			streamer := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string,
+				opts ...grpc.CallOption) (stream grpc.ClientStream, err error) {
+				stream = &mockClientStream{
+					ctx: ctx,
+				}
+				return
+			}
+
+			// Add metadata to context:
+			ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", "Bearer my_token"))
+
+			// Call the interceptor:
+			stream, err := interceptor.StreamClient(ctx, desc, conn, method, streamer)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stream).ToNot(BeNil())
+
+			// Use the stream to trigger object logging:
+			object := &testsv1.Object{MyString: "my_value", Id: "my_id"}
+			err = stream.SendMsg(object)
+			Expect(err).ToNot(HaveOccurred())
+			err = stream.RecvMsg(object)
+			Expect(err).To(Equal(io.EOF))
+
+			// Parse the log messages:
+			messages := Parse(buffer)
+			Expect(messages).To(HaveLen(1))
+
+			// Verify send log:
+			sendMessage := messages[0]
+			Expect(sendMessage["msg"]).To(Equal("Sent stream message"))
+		})
+
+		It("Skips logging for reflection methods", func() {
+			method := "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo"
+			desc := &grpc.StreamDesc{}
+
+			// Mock stream:
+			mockStream := &mockClientStream{ctx: ctx}
+
+			// Mock streamer:
+			streamer := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string,
+				opts ...grpc.CallOption) (grpc.ClientStream, error) {
+				return mockStream, nil
+			}
+
+			// Call the interceptor:
+			stream, err := interceptor.StreamClient(ctx, desc, conn, method, streamer)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stream).To(Equal(mockStream)) // Should return original stream
+
+			// Parse the log messages - should be empty:
+			messages := Parse(buffer)
+			Expect(messages).To(BeEmpty())
+		})
+	})
+})
+
+type mockClientStream struct {
+	ctx context.Context
+}
+
+func (m *mockClientStream) Context() context.Context {
+	return m.ctx
+}
+
+func (m *mockClientStream) Header() (result metadata.MD, err error) {
+	result = metadata.New(map[string]string{
+		"my_header": "my_value",
+	})
+	return
+}
+
+func (m *mockClientStream) Trailer() metadata.MD {
+	return metadata.New(map[string]string{
+		"my_trailer": "my_value",
+	})
+}
+
+func (m *mockClientStream) CloseSend() error {
+	return nil
+}
+
+func (m *mockClientStream) SendMsg(message any) error {
+	return nil
+}
+
+func (m *mockClientStream) RecvMsg(message any) error {
+	return io.EOF
+}


### PR DESCRIPTION
This patch adds a gRPC interceptor that writes to the log the details of the requests and responses when the `debug` level is enabled.