### PR TITLE
Add version and user agent

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,6 +21,8 @@ builds:
   - linux
   - windows
   - darwin
+  ldflags:
+  - -X github.com/innabox/fulfillment-cli/internal/version.id={{ .Version }}
 
 archives:
 - formats: [tar.gz]

--- a/internal/cmd/create/cluster/create_cluster_cmd.go
+++ b/internal/cmd/create/cluster/create_cluster_cmd.go
@@ -64,7 +64,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create the gRPC connection from the configuration:
-	conn, err := cfg.Connect(ctx)
+	conn, err := cfg.Connect(ctx, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}

--- a/internal/cmd/create/create_cmd.go
+++ b/internal/cmd/create/create_cmd.go
@@ -79,7 +79,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create the gRPC connection from the configuration:
-	c.conn, err = cfg.Connect(ctx)
+	c.conn, err = cfg.Connect(ctx, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}

--- a/internal/cmd/create/hub/create_hub_cmd.go
+++ b/internal/cmd/create/hub/create_hub_cmd.go
@@ -91,7 +91,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create the gRPC connection from the configuration:
-	conn, err := cfg.Connect(ctx)
+	conn, err := cfg.Connect(ctx, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}

--- a/internal/cmd/delete/delete_cmd.go
+++ b/internal/cmd/delete/delete_cmd.go
@@ -70,7 +70,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create the gRPC connection from the configuration:
-	c.conn, err = cfg.Connect(ctx)
+	c.conn, err = cfg.Connect(ctx, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}

--- a/internal/cmd/describe/cluster/describe_cluster.go
+++ b/internal/cmd/describe/cluster/describe_cluster.go
@@ -63,7 +63,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create the gRPC connection from the configuration:
-	conn, err := cfg.Connect(ctx)
+	conn, err := cfg.Connect(ctx, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}

--- a/internal/cmd/edit/edit_cmd.go
+++ b/internal/cmd/edit/edit_cmd.go
@@ -101,7 +101,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create the gRPC connection from the configuration:
-	c.conn, err = cfg.Connect(ctx)
+	c.conn, err = cfg.Connect(ctx, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}
@@ -165,7 +165,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	objectId := args[1]
 
 	// Create the gRPC connection from the configuration:
-	c.conn, err = cfg.Connect(ctx)
+	c.conn, err = cfg.Connect(ctx, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}

--- a/internal/cmd/get/get_cmd.go
+++ b/internal/cmd/get/get_cmd.go
@@ -132,7 +132,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create the gRPC connection from the configuration:
-	c.conn, err = cfg.Connect(ctx)
+	c.conn, err = cfg.Connect(ctx, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}

--- a/internal/cmd/get/kubeconfig/get_kubeconfig_cmd.go
+++ b/internal/cmd/get/kubeconfig/get_kubeconfig_cmd.go
@@ -54,7 +54,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	// Get the context:
 	ctx := cmd.Context()
 
-	// Get the logger:
+	// Get the logger and flags:
 	c.logger = logging.LoggerFromContext(ctx)
 
 	// Get the configuration:
@@ -67,7 +67,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create the gRPC connection from the configuration:
-	c.conn, err = cfg.Connect(ctx)
+	c.conn, err = cfg.Connect(ctx, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}

--- a/internal/cmd/get/password/get_password_cmd.go
+++ b/internal/cmd/get/password/get_password_cmd.go
@@ -67,7 +67,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create the gRPC connection from the configuration:
-	c.conn, err = cfg.Connect(ctx)
+	c.conn, err = cfg.Connect(ctx, cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}

--- a/internal/cmd/root_cmd.go
+++ b/internal/cmd/root_cmd.go
@@ -28,6 +28,7 @@ import (
 	"github.com/innabox/fulfillment-cli/internal/cmd/get"
 	"github.com/innabox/fulfillment-cli/internal/cmd/login"
 	"github.com/innabox/fulfillment-cli/internal/cmd/logout"
+	"github.com/innabox/fulfillment-cli/internal/cmd/version"
 	"github.com/innabox/fulfillment-cli/internal/logging"
 	"github.com/innabox/fulfillment-cli/internal/terminal"
 )
@@ -54,6 +55,7 @@ func Root() *cobra.Command {
 	result.AddCommand(get.Cmd())
 	result.AddCommand(login.Cmd())
 	result.AddCommand(logout.Cmd())
+	result.AddCommand(version.Cmd())
 
 	return result
 }

--- a/internal/cmd/version/version_cmd.go
+++ b/internal/cmd/version/version_cmd.go
@@ -1,0 +1,46 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package version
+
+import (
+	"github.com/innabox/fulfillment-cli/internal/terminal"
+	"github.com/innabox/fulfillment-cli/internal/version"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:   "version",
+		Short: "Display version details",
+		RunE:  runner.run,
+	}
+	return result
+}
+
+type runnerContext struct {
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	// Get the context:
+	ctx := cmd.Context()
+
+	// Get the console:
+	console := terminal.ConsoleFromContext(ctx)
+
+	// Print the version:
+	console.Printf(ctx, "%s\n", version.Get())
+
+	return nil
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package version
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// Unknown is the constant value used when version information is not available.
+const Unknown = "unknown"
+
+// This will be injected into the binary during the build.
+var id = Unknown
+
+func init() {
+	if id != Unknown {
+		return
+	}
+	info, ok := debug.ReadBuildInfo()
+	if ok {
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				id = setting.Value
+			}
+		}
+	}
+}
+
+// Get returns the version identifier.
+func Get() string {
+	return strings.TrimPrefix(id, "v")
+}
+
+// Set sets the version identifier. This is intended for unit tests and there is no reason to call it in other contexts.
+func Set(value string) {
+	id = value
+}

--- a/internal/version/version_interceptor.go
+++ b/internal/version/version_interceptor.go
@@ -1,0 +1,155 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package version
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// InterceptorBuilder contains the data and logic needed to build an interceptor that adds version information to the
+// gRPC calls. Don't create instances of this type directly, use the NewInterceptor function instead.
+type InterceptorBuilder struct {
+	logger  *slog.Logger
+	product string
+	version string
+}
+
+// Interceptor contains the data needed by the interceptor.
+type Interceptor struct {
+	logger  *slog.Logger
+	product string
+	version string
+}
+
+// NewInterceptor creates a builder that can then be used to configure and create a interceptor.
+func NewInterceptor() *InterceptorBuilder {
+	return &InterceptorBuilder{}
+}
+
+// SetLogger sets the logger that will be used by the intercetor. This is mandatory.
+func (b *InterceptorBuilder) SetLogger(value *slog.Logger) *InterceptorBuilder {
+	b.logger = value
+	return b
+}
+
+// SetProduct sets the product name that will be used in the user agent header.
+func (b *InterceptorBuilder) SetProduct(value string) *InterceptorBuilder {
+	b.product = value
+	return b
+}
+
+// SetVersion sets the version that will be used in the user agent header.
+func (b *InterceptorBuilder) SetVersion(value string) *InterceptorBuilder {
+	b.version = value
+	return b
+}
+
+// defaultProduct calculates the default product name from the binary path.
+func (b *InterceptorBuilder) defaultProduct() string {
+	executable, err := os.Executable()
+	if err != nil {
+		if b.logger != nil {
+			b.logger.Warn(
+				"Failed to get executable path for product name",
+				slog.Any("error", err),
+			)
+		}
+		return Unknown
+	}
+	return filepath.Base(executable)
+}
+
+// defaultVersion calculates the default version from version.Get() or git information.
+func (b *InterceptorBuilder) defaultVersion() string {
+	// First try the injected version:
+	version := Get()
+	if version != Unknown {
+		return version
+	}
+
+	// Fall back to git information from build info:
+	info, ok := debug.ReadBuildInfo()
+	if ok {
+		var revision string
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				revision = setting.Value
+			}
+		}
+		if revision != "" {
+			return revision
+		}
+	}
+
+	return Unknown
+}
+
+// Build uses the data stored in the builder to create and configure a new interceptor.
+func (b *InterceptorBuilder) Build() (result *Interceptor, err error) {
+	// Check parameters:
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+
+	// Use provided values or defaults:
+	product := b.product
+	if product == "" {
+		product = b.defaultProduct()
+	}
+	version := b.version
+	if version == "" {
+		version = b.defaultVersion()
+	}
+
+	// Create and populate the object:
+	result = &Interceptor{
+		logger:  b.logger,
+		product: product,
+		version: version,
+	}
+	return
+}
+
+// userAgent calculates the value for the `User-Agent` header.
+func (i *Interceptor) userAgentHeaderValue() string {
+	return fmt.Sprintf("%s/%s", i.product, i.version)
+}
+
+// UnaryClient is the unary client interceptor function that adds the version details.
+func (i *Interceptor) UnaryClient(ctx context.Context, method string, request, response any,
+	conn *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	ctx = metadata.AppendToOutgoingContext(ctx, userAgentHeaderName, i.userAgentHeaderValue())
+	return invoker(ctx, method, request, response, conn, opts...)
+}
+
+// StreamClient is the stream client interceptor function that adds the user agent header.
+func (i *Interceptor) StreamClient(ctx context.Context, desc *grpc.StreamDesc, conn *grpc.ClientConn, method string,
+	streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	ctx = metadata.AppendToOutgoingContext(ctx, userAgentHeaderName, i.userAgentHeaderValue())
+	return streamer(ctx, desc, conn, method, opts...)
+}
+
+// userAgentHeaderName is the name of the user agent header.
+const userAgentHeaderName = "User-Agent"

--- a/internal/version/version_interceptor_test.go
+++ b/internal/version/version_interceptor_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package version
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+)
+
+var _ = Describe("Interceptor", func() {
+	Describe("Creation", func() {
+		It("Can be created with all the mandatory parameters", func() {
+			interceptor, err := NewInterceptor().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(interceptor).ToNot(BeNil())
+			Expect(interceptor.product).ToNot(BeEmpty())
+		})
+
+		It("Can be created with a custom product", func() {
+			interceptor, err := NewInterceptor().
+				SetLogger(logger).
+				SetProduct("my_product").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(interceptor).ToNot(BeNil())
+		})
+
+		It("Can be created with a custom version", func() {
+			interceptor, err := NewInterceptor().
+				SetLogger(logger).
+				SetVersion("2.0.0").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(interceptor).ToNot(BeNil())
+		})
+
+		It("Can be created with both custom product and version", func() {
+			interceptor, err := NewInterceptor().
+				SetLogger(logger).
+				SetProduct("my_product").
+				SetVersion("2.0.0").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(interceptor).ToNot(BeNil())
+		})
+
+		It("Can't be created without a logger", func() {
+			interceptor, err := NewInterceptor().
+				Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("logger is mandatory"))
+			Expect(interceptor).To(BeNil())
+		})
+	})
+
+	Describe("Behaviour", func() {
+		var (
+			ctx         context.Context
+			server      *grpc.Server
+			listener    net.Listener
+			conn        *grpc.ClientConn
+			interceptor *Interceptor
+		)
+
+		BeforeEach(func() {
+			var err error
+
+			// Create the context:
+			ctx = context.Background()
+
+			// Create the interceptor:
+			interceptor, err = NewInterceptor().
+				SetProduct("my_product").
+				SetVersion("2.0.0").
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create a test server:
+			listener, err = net.Listen("tcp", "127.0.0.1:0")
+			Expect(err).ToNot(HaveOccurred())
+			server = grpc.NewServer()
+			go func() {
+				defer GinkgoRecover()
+				_ = server.Serve(listener)
+			}()
+			DeferCleanup(server.Stop)
+
+			// Create a client connection with interceptor:
+			conn, err = grpc.NewClient(
+				listener.Addr().String(),
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				grpc.WithUnaryInterceptor(interceptor.UnaryClient),
+				grpc.WithStreamInterceptor(interceptor.StreamClient),
+			)
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(conn.Close)
+		})
+
+		Describe("Unary client", func() {
+			It("Adds user agent header to unary client requests", func() {
+				// Mock invoker that captures metadata:
+				var md metadata.MD
+				invoker := func(ctx context.Context, _ string, _ any, _ any, _ *grpc.ClientConn,
+					_ ...grpc.CallOption) error {
+					var ok bool
+					md, ok = metadata.FromOutgoingContext(ctx)
+					Expect(ok).To(BeTrue())
+					return nil
+				}
+
+				// Call the interceptor:
+				err := interceptor.UnaryClient(ctx, "", nil, nil, conn, invoker)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify user agent was added:
+				header := md.Get("User-Agent")
+				Expect(header).To(HaveLen(1))
+				Expect(header[0]).To(Equal("my_product/2.0.0"))
+			})
+
+			It("Preserves existing metadata", func() {
+				// Create context with existing metadata:
+				ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("My-Header", "my_value"))
+
+				// Mock invoker that captures metadata:
+				var md metadata.MD
+				invoker := func(ctx context.Context, _ string, _ any, _ any, _ *grpc.ClientConn,
+					_ ...grpc.CallOption) error {
+					var ok bool
+					md, ok = metadata.FromOutgoingContext(ctx)
+					Expect(ok).To(BeTrue())
+					return nil
+				}
+
+				// Call the interceptor:
+				err := interceptor.UnaryClient(ctx, "", nil, nil, conn, invoker)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify both headers are present:
+				header := md.Get("User-Agent")
+				Expect(header).To(HaveLen(1))
+				Expect(header[0]).To(Equal("my_product/2.0.0"))
+				header = md.Get("My-Header")
+				Expect(header).To(HaveLen(1))
+				Expect(header[0]).To(Equal("my_value"))
+			})
+
+			It("Forwards invoker errors", func() {
+				// Mock invoker that returns an error:
+				invoker := func(context.Context, string, any, any, *grpc.ClientConn,
+					...grpc.CallOption) error {
+					return errors.New("my error")
+				}
+
+				// Call the interceptor:
+				err := interceptor.UnaryClient(ctx, "", nil, nil, conn, invoker)
+				Expect(err).To(MatchError("my error"))
+			})
+		})
+	})
+})

--- a/internal/version/version_suite_test.go
+++ b/internal/version/version_suite_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package version
+
+import (
+	"log/slog"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+
+	"github.com/innabox/fulfillment-cli/internal/logging"
+)
+
+func TestVersion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Version")
+}
+
+var logger *slog.Logger
+
+var _ = BeforeSuite(func() {
+	var err error
+	logger, err = logging.NewLogger().
+		SetLevel(slog.LevelDebug.String()).
+		SetWriter(GinkgoWriter).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package version
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Get", func() {
+	When("Version has 'v' prefix", func() {
+		BeforeEach(func() {
+			value := Get()
+			Set("v1.2.3")
+			DeferCleanup(func() {
+				Set(value)
+			})
+		})
+
+		It("Removes the prefix", func() {
+			Expect(Get()).To(Equal("1.2.3"))
+		})
+	})
+
+	When("Version has no 'v' prefix", func() {
+		BeforeEach(func() {
+			value := Get()
+			Set("v1.2.3")
+			DeferCleanup(func() {
+				Set(value)
+			})
+		})
+
+		It("Returns value without changes", func() {
+			Expect(Get()).To(Equal("1.2.3"))
+		})
+	})
+
+	When("Version is unknown", func() {
+		BeforeEach(func() {
+			value := Get()
+			Set(Unknown)
+			DeferCleanup(func() {
+				Set(value)
+			})
+		})
+
+		It("Returns git hash", func() {
+			Expect(Get()).To(Equal(Unknown))
+		})
+	})
+})


### PR DESCRIPTION
This patch adds a new `version` command that displays the version identifier the tool:

```shell
$ fulfillment-cli version
0.0.4
```

It also adds the `User-Agent` header to requests. The value of the header will be `fulfillment-service/` followed by the version number.

For releases the version number will be the result of `git describe --tags`. For example, for release 0.0.4 the complete user agent will be `fulfillment-cli/0.0.4`.

For unreleased versions, including versions built from source using `go build` the version number will be the git hash.