### PR TITLE
Fetch git history before release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,8 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - uses: ./.github/actions/setup-go
     - uses: goreleaser/goreleaser-action@v6
       with:


### PR DESCRIPTION
This patch changes the GitHub workflow that publishes releases so that it fetches the full git history, as otherwise the _goreleaser_ tool will not be able to add to the release all the changes.