### PR TITLE
Wrap CEL table expressions in 'this' object to enable namespace column

### DIFF
--- a/internal/cmd/get/get_table.go
+++ b/internal/cmd/get/get_table.go
@@ -32,7 +32,7 @@ type Column struct {
 	Width int `yaml:"width,omitempty"`
 
 	// Value is a CEL expression that will be used to calculate the rendered value. The expression can access
-	// the message via the `message` built-in variable.
+	// the message via the `this` built-in variable.
 	Value string `yaml:"value,omitempty"`
 
 	// Type is the name of a enum type that is the result of evaluationg the expression. This is needed because

--- a/internal/cmd/get/tables/fulfillment.v1.Cluster.yaml
+++ b/internal/cmd/get/tables/fulfillment.v1.Cluster.yaml
@@ -14,18 +14,18 @@
 columns:
 
 - header: ID
-  value: id
+  value: this.id
   width: 100
 
 - header: TEMPLATE
-  value: spec.template
+  value: this.spec.template
 
 - header: STATE
-  value: status.state
+  value: this.status.state
   type: fulfillment.v1.ClusterState
 
 - header: API URL
-  value: "has(status.api_url)? status.api_url: '-'"
+  value: "has(this.status.api_url)? this.status.api_url: '-'"
 
 - header: CONSOLE URL
-  value: "has(status.console_url)? status.console_url: '-'"
+  value: "has(this.status.console_url)? this.status.console_url: '-'"

--- a/internal/cmd/get/tables/fulfillment.v1.ClusterTemplate.yaml
+++ b/internal/cmd/get/tables/fulfillment.v1.ClusterTemplate.yaml
@@ -14,10 +14,10 @@
 columns:
 
 - header: ID
-  value: id
+  value: this.id
 
 - header: TITLE
-  value: title
+  value: this.title
 
 - header: DESCRIPTION
-  value: description
+  value: this.description

--- a/internal/cmd/get/tables/private.v1.Cluster.yaml
+++ b/internal/cmd/get/tables/private.v1.Cluster.yaml
@@ -14,20 +14,20 @@
 columns:
 
 - header: ID
-  value: id
+  value: this.id
 
 - header: TEMPLATE
-  value: spec.template
+  value: this.spec.template
 
 - header: STATE
-  value: status.state
+  value: this.status.state
   type: fulfillment.v1.ClusterState
 
 - header: HUB
-  value: status.hub
+  value: this.status.hub
 
 - header: API URL
-  value: "has(status.api_url)? status.api_url: '-'"
+  value: "has(this.status.api_url)? this.status.api_url: '-'"
 
 - header: CONSOLE URL
-  value: "has(status.console_url)? status.console_url: '-'"
+  value: "has(this.status.console_url)? this.status.console_url: '-'"

--- a/internal/cmd/get/tables/private.v1.ClusterTemplate.yaml
+++ b/internal/cmd/get/tables/private.v1.ClusterTemplate.yaml
@@ -14,10 +14,10 @@
 columns:
 
 - header: ID
-  value: id
+  value: this.id
 
 - header: TITLE
-  value: title
+  value: this.title
 
 - header: DESCRIPTION
-  value: description
+  value: this.description

--- a/internal/cmd/get/tables/private.v1.Hub.yaml
+++ b/internal/cmd/get/tables/private.v1.Hub.yaml
@@ -14,4 +14,11 @@
 columns:
 
 - header: ID
-  value: id
+  value: this.id
+
+- header: NAMESPACE
+  value: this.namespace
+
+- header: KUBECONFIG
+  value: |
+    "%d bytes".format([size(this.kubeconfig)])


### PR DESCRIPTION
This change was needed to add a NAMESPACE column to the hubs table. Previously, CEL expressions accessed object fields directly (e.g., 'id', 'spec.template'), but this didn't work for reserved words like 'namespace'. Attempts to work around this using backticks ("`namespace`") failed to resolve the issue.

To properly support the namespace field and avoid future reserved word conflicts, this change wraps protobuf objects in a top-level 'this' field when evaluating CEL expressions in table columns.

Changes:
- Modified renderTableRow() to wrap objects in map with 'this' key
- Updated CEL environment to declare 'this' variable instead of using ContextProtoVars
- Added ext.Strings() library to enable string formatting functions like format()
- Updated all table YAML files to use 'this.' prefix for field access
- Added NAMESPACE column to hubs table using clean 'this.namespace' syntax
- Updated default table and deletion timestamp column to use 'this.' prefix
- Updated documentation to reflect new 'this' variable usage

The change maintains consistency with server-side filtering which already uses 'this.metadata.deletion_timestamp' pattern. While solving the immediate namespace issue, this provides a general solution for any future reserved word conflicts and enables more complex CEL expressions with string formatting functions.