### PR TITLE
Add `--template-parameter` and `--template-parameter-file`

### DIFF
--- a/internal/cmd/create/cluster/create_cluster_cmd.go
+++ b/internal/cmd/create/cluster/create_cluster_cmd.go
@@ -14,15 +14,36 @@ language governing permissions and limitations under the License.
 package cluster
 
 import (
+	"context"
+	"embed"
+	"errors"
 	"fmt"
+	"log/slog"
 	"os"
-	"text/tabwriter"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	ffv1 "github.com/innabox/fulfillment-cli/internal/api/fulfillment/v1"
 	"github.com/innabox/fulfillment-cli/internal/config"
+	"github.com/innabox/fulfillment-cli/internal/exit"
+	"github.com/innabox/fulfillment-cli/internal/logging"
+	"github.com/innabox/fulfillment-cli/internal/templating"
+	"github.com/innabox/fulfillment-cli/internal/terminal"
 )
+
+//go:embed templates
+var templatesFS embed.FS
 
 func Cmd() *cobra.Command {
 	runner := &runnerContext{}
@@ -32,22 +53,60 @@ func Cmd() *cobra.Command {
 		RunE:  runner.run,
 	}
 	flags := result.Flags()
-	flags.StringVar(
+	flags.StringVarP(
 		&runner.template,
 		"template",
+		"t",
 		"",
 		"Template identifier",
+	)
+	flags.StringSliceVarP(
+		&runner.templateParameterValues,
+		"template-parameter",
+		"p",
+		[]string{},
+		"Template parameter in the format 'name=value'",
+	)
+	flags.StringSliceVarP(
+		&runner.templateParameterFiles,
+		"template-parameter-file",
+		"f",
+		[]string{},
+		"Template parameter from file in the format 'name=filename'",
 	)
 	return result
 }
 
 type runnerContext struct {
-	template string
+	template                string
+	templateParameterValues []string
+	templateParameterFiles  []string
+	logger                  *slog.Logger
+	console                 *terminal.Console
+	engine                  *templating.Engine
+	templatesClient         ffv1.ClusterTemplatesClient
+	clustersClient          ffv1.ClustersClient
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	var err error
+
 	// Get the context:
 	ctx := cmd.Context()
+
+	// Get the logger and console:
+	c.logger = logging.LoggerFromContext(ctx)
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	// Create the templating engine:
+	c.engine, err = templating.NewEngine().
+		SetLogger(c.logger).
+		SetFS(templatesFS).
+		SetDir("templates").
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create templating engine: %w", err)
+	}
 
 	// Get the configuration:
 	cfg, err := config.Load()
@@ -68,30 +127,448 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection: %w", err)
 	}
+	defer conn.Close()
 
-	// Create the client for the cluster orders service:
-	client := ffv1.NewClustersClient(conn)
+	// Create the gRPC clients:
+	c.templatesClient = ffv1.NewClusterTemplatesClient(conn)
+	c.clustersClient = ffv1.NewClustersClient(conn)
+
+	// Fetch the cluster template:
+	templateResponse, err := c.templatesClient.Get(ctx, ffv1.ClusterTemplatesGetRequest_builder{
+		Id: c.template,
+	}.Build())
+	if err != nil {
+		status, ok := grpcstatus.FromError(err)
+		if ok {
+			if status.Code() == grpccodes.NotFound {
+				templatesResponse, err := c.templatesClient.List(ctx, ffv1.ClusterTemplatesListRequest_builder{
+					Limit: proto.Int32(50),
+				}.Build())
+				if err != nil {
+					return fmt.Errorf("failed to list templates: %w", err)
+				}
+				templates := templatesResponse.GetItems()
+				sort.Slice(templates, func(i, j int) bool {
+					return templates[i].GetId() < templates[j].GetId()
+				})
+				c.console.Render(ctx, c.engine, "template_not_found.txt", map[string]any{
+					"Binary":    os.Args[0],
+					"Template":  c.template,
+					"Templates": templates,
+				})
+				return exit.Error(1)
+			}
+			return fmt.Errorf("failed to get template '%s': %w", c.template, err)
+		}
+		return fmt.Errorf("failed to get template '%s': %w", c.template, err)
+	}
+	template := templateResponse.Object
+	if template == nil {
+		return exit.Error(1)
+	}
+
+	// Parse the template parameters:
+	templateParameterValues, templateParameterIssues := c.parseTemplateParameters(ctx, template)
+	if len(templateParameterIssues) > 0 {
+		validTemplateParameters := c.validTemplateParameters(template)
+		c.console.Render(ctx, c.engine, "template_parameter_issues.txt", map[string]any{
+			"Binary":     os.Args[0],
+			"Template":   c.template,
+			"Parameters": validTemplateParameters,
+			"Issues":     templateParameterIssues,
+		})
+		return exit.Error(1)
+	}
 
 	// Prepare the cluster:
 	cluster := ffv1.Cluster_builder{
 		Spec: ffv1.ClusterSpec_builder{
-			Template: c.template,
+			Template:           c.template,
+			TemplateParameters: templateParameterValues,
 		}.Build(),
 	}.Build()
 
 	// Create the cluster:
-	response, err := client.Create(ctx, ffv1.ClustersCreateRequest_builder{
+	response, err := c.clustersClient.Create(ctx, ffv1.ClustersCreateRequest_builder{
 		Object: cluster,
 	}.Build())
 	if err != nil {
-		return fmt.Errorf("failed to create: %w", err)
+		return fmt.Errorf("failed to create cluster: %w", err)
 	}
 
 	// Display the result:
 	cluster = response.Object
-	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(writer, "ID: %s\n", cluster.Id)
-	writer.Flush()
+	c.console.Printf(ctx, "Created cluster '%s'.\n", cluster.Id)
 
 	return nil
+}
+
+// parseTemplateParameters parses the '--template-parameter' and '--template-parameter-file' flags into a map of
+// parameter name to value, and a list of issues found. The issues are intended for display to the user.
+func (c *runnerContext) parseTemplateParameters(ctx context.Context,
+	template *ffv1.ClusterTemplate) (result map[string]*anypb.Any, issues []string) {
+	// Prepare empty results and issues:
+	result = map[string]*anypb.Any{}
+
+	// Make a map of parameter definitions indexed by name for quick lookup:
+	definitions := map[string]*ffv1.ClusterTemplateParameterDefinition{}
+	for _, definition := range template.GetParameters() {
+		definitions[definition.GetName()] = definition
+	}
+
+	// Parse '--template-parameter' flags:
+	for _, flag := range c.templateParameterValues {
+		parts := strings.SplitN(flag, "=", 2)
+		if len(parts) != 2 {
+			name := strings.TrimSpace(flag)
+			definition := definitions[name]
+			if definition == nil {
+				issues = append(
+					issues,
+					fmt.Sprintf(
+						"In '%s' parameter '%s' doesn't exist, and if it existed the value "+
+							"would be missing",
+						flag, name,
+					),
+				)
+			} else {
+				issues = append(
+					issues,
+					fmt.Sprintf(
+						"In '%s' parameter value is missing",
+						flag,
+					),
+				)
+			}
+			continue
+		}
+		name := strings.TrimSpace(parts[0])
+		if name == "" {
+			issues = append(
+				issues,
+				fmt.Sprintf(
+					"In '%s' parameter name is missing",
+					flag,
+				),
+			)
+			continue
+		}
+		definition := definitions[name]
+		if definition == nil {
+			issues = append(
+				issues,
+				fmt.Sprintf(
+					"In '%s' parameter '%s' doesn't exist",
+					flag, name,
+				),
+			)
+			continue
+		}
+		text := strings.TrimSpace(parts[1])
+		value, issue := c.convertTextToTemplateParameterValue(ctx, text, definition.GetType())
+		if issue != "" {
+			issues = append(issues, fmt.Sprintf("In '%s' %s", flag, issue))
+			continue
+		}
+		result[name] = value
+	}
+
+	// Parse '--template-parameter-file' flags:
+	for _, flag := range c.templateParameterFiles {
+		parts := strings.SplitN(flag, "=", 2)
+		if len(parts) != 2 {
+			name := strings.TrimSpace(flag)
+			definition := definitions[name]
+			if definition == nil {
+				issues = append(issues, fmt.Sprintf(
+					"In '%s' parameter '%s' doesn't exist, and if existed the file would be "+
+						"missing",
+					flag, name,
+				))
+			} else {
+				issues = append(
+					issues,
+					fmt.Sprintf(
+						"In '%s' file is missing",
+						flag,
+					))
+			}
+			continue
+		}
+		name := strings.TrimSpace(parts[0])
+		if name == "" {
+			issues = append(
+				issues,
+				fmt.Sprintf(
+					"In '%s' parameter name is missing",
+					flag,
+				),
+			)
+			continue
+		}
+		definition := definitions[name]
+		if definition == nil {
+			issues = append(
+				issues,
+				fmt.Sprintf(
+					"In '%s' parameter '%s' doesn't exist",
+					flag, name,
+				),
+			)
+			continue
+		}
+		file := strings.TrimSpace(parts[1])
+		if file == "" {
+			issues = append(
+				issues,
+				fmt.Sprintf(
+					"In '%s' file is missing",
+					flag,
+				),
+			)
+			continue
+		}
+		data, err := os.ReadFile(file)
+		if errors.Is(err, os.ErrNotExist) {
+			issues = append(
+				issues, fmt.Sprintf(
+					"In '%s' file '%s' doesn't exist",
+					flag, file,
+				),
+			)
+			continue
+		}
+		if err != nil {
+			issues = append(
+				issues,
+				fmt.Sprintf(
+					"In '%s' failed to read file '%s': %w",
+					file, err,
+				),
+			)
+			continue
+		}
+		text := string(data)
+		value, issue := c.convertTextToTemplateParameterValue(ctx, text, definition.GetType())
+		if issue != "" {
+			issues = append(
+				issues,
+				fmt.Sprintf("In '%s' %s'", flag, issue),
+			)
+			continue
+		}
+		result[name] = value
+	}
+
+	// Add issues for missing required parameters, at the end of the list and sorted by parameter name:
+	var missing []*ffv1.ClusterTemplateParameterDefinition
+	for _, definition := range template.GetParameters() {
+		if definition.GetRequired() && result[definition.GetName()] == nil {
+			missing = append(missing, definition)
+		}
+	}
+	sort.Slice(missing, func(i, j int) bool {
+		return missing[i].GetName() < missing[j].GetName()
+	})
+	for _, definition := range missing {
+		issues = append(
+			issues,
+			fmt.Sprintf("Parameter '%s' is required", definition.GetName()),
+		)
+	}
+
+	return
+}
+
+// convertTextToTemplateParameterValue converts a string value to the appropriate protobuf type based on the kind. It
+// returns the value and a string descibing the issue if the conversion fails.
+func (c *runnerContext) convertTextToTemplateParameterValue(ctx context.Context, text,
+	kind string) (result *anypb.Any, issue string) {
+	var wrapper proto.Message
+	switch kind {
+	case "type.googleapis.com/google.protobuf.StringValue":
+		wrapper = &wrapperspb.StringValue{Value: text}
+	case "type.googleapis.com/google.protobuf.BoolValue":
+		text = strings.TrimSpace(text)
+		value, err := strconv.ParseBool(text)
+		if err != nil {
+			c.logger.DebugContext(
+				ctx,
+				"Failed to parse boolean",
+				slog.String("text", text),
+				slog.Any("error", err),
+			)
+			issue = fmt.Sprintf(
+				"value '%s' isn't a valid boolean, valid values are 'true' and 'false'",
+				text,
+			)
+			return
+		}
+		wrapper = &wrapperspb.BoolValue{Value: value}
+	case "type.googleapis.com/google.protobuf.Int32Value":
+		text = strings.TrimSpace(text)
+		var value int64
+		value, err := strconv.ParseInt(text, 10, 32)
+		if err != nil {
+			c.logger.DebugContext(
+				ctx,
+				"Failed to parse 32-bit integer number",
+				slog.String("text", text),
+				slog.Any("error", err),
+			)
+			issue = fmt.Sprintf("value '%s' isn't a valid 32-bit integer", text)
+			return
+		}
+		wrapper = &wrapperspb.Int32Value{Value: int32(value)}
+	case "type.googleapis.com/google.protobuf.Int64Value":
+		text = strings.TrimSpace(text)
+		var value int64
+		value, err := strconv.ParseInt(text, 10, 64)
+		if err != nil {
+			c.logger.DebugContext(
+				ctx,
+				"Failed to parse 64-bit integer number",
+				slog.String("text", text),
+				slog.Any("error", err),
+			)
+			issue = fmt.Sprintf("value '%s' isn't a valid 64-bit integer", text)
+			return
+		}
+		wrapper = &wrapperspb.Int64Value{Value: value}
+	case "type.googleapis.com/google.protobuf.FloatValue":
+		text = strings.TrimSpace(text)
+		var value float64
+		value, err := strconv.ParseFloat(text, 32)
+		if err != nil {
+			c.logger.DebugContext(
+				ctx,
+				"Failed to parse 32-bit floating point number",
+				slog.String("text", text),
+				slog.Any("error", err),
+			)
+			issue = fmt.Sprintf("value '%s' isn't a valid 32-bit floating point number", text)
+			return
+		}
+		wrapper = &wrapperspb.FloatValue{Value: float32(value)}
+	case "type.googleapis.com/google.protobuf.DoubleValue":
+		text = strings.TrimSpace(text)
+		var value float64
+		value, err := strconv.ParseFloat(text, 64)
+		if err != nil {
+			c.logger.DebugContext(
+				ctx,
+				"Failed to parse 64-bit floating point number",
+				slog.String("text", text),
+				slog.Any("error", err),
+			)
+			issue = fmt.Sprintf("value '%s' isn't a valid 64-bit floating point numberw", text)
+			return
+		}
+		wrapper = &wrapperspb.DoubleValue{Value: value}
+	case "type.googleapis.com/google.protobuf.BytesValue":
+		wrapper = &wrapperspb.BytesValue{Value: []byte(text)}
+	case "type.googleapis.com/google.protobuf.Timestamp":
+		text = strings.TrimSpace(text)
+		var value time.Time
+		value, err := time.Parse(time.RFC3339, text)
+		if err != nil {
+			c.logger.DebugContext(
+				ctx,
+				"Failed to parse RFC3339 timestamp",
+				slog.String("text", text),
+				slog.Any("error", err),
+			)
+			issue = fmt.Sprintf("value '%s' isn't a valid RFC3339 timestamp", text)
+			return
+		}
+		wrapper = timestamppb.New(value)
+	case "type.googleapis.com/google.protobuf.Duration":
+		var value time.Duration
+		value, err := time.ParseDuration(text)
+		if err != nil {
+			c.logger.DebugContext(
+				ctx,
+				"Failed to parse duration",
+				slog.String("text", text),
+				slog.Any("error", err),
+			)
+			issue = fmt.Sprintf("value '%s' isn't a valid duration", text)
+			return
+		}
+		wrapper = durationpb.New(value)
+	default:
+		issue = fmt.Sprintf("flag has is of an unsupported type '%s'", kind)
+		return
+	}
+	if issue != "" {
+		return
+	}
+	result, err := anypb.New(wrapper)
+	if err != nil {
+		c.logger.DebugContext(
+			ctx,
+			"Failed to create protobuf value for template parameter",
+			slog.String("text", text),
+			slog.String("kind", kind),
+			slog.Any("error", err),
+		)
+		issue = fmt.Sprintf("Failed to create protobuf value for template parameter: %w", err)
+		return
+	}
+	return
+}
+
+// validTemplateParameter contains the information about a valid template parameter, for use in the error messages that
+// display them.
+type validTemplateParameter struct {
+	// Name is the name of the parameter.
+	Name string
+
+	// Type is the type of the parameter.
+	Type string
+
+	// Title is the title of the parameter.
+	Title string
+}
+
+// validTemplateParameters returns the list of valid template parameters for the given template.
+func (c *runnerContext) validTemplateParameters(template *ffv1.ClusterTemplate) []validTemplateParameter {
+	// Prepare the results:
+	results := []validTemplateParameter{}
+	for _, parameter := range template.GetParameters() {
+		result := validTemplateParameter{
+			Name:  parameter.GetName(),
+			Title: parameter.GetTitle(),
+		}
+		switch parameter.GetType() {
+		case "type.googleapis.com/google.protobuf.StringValue":
+			result.Type = "string"
+		case "type.googleapis.com/google.protobuf.BoolValue":
+			result.Type = "boolean"
+		case "type.googleapis.com/google.protobuf.Int32Value":
+			result.Type = "int32"
+		case "type.googleapis.com/google.protobuf.Int64Value":
+			result.Type = "int64"
+		case "type.googleapis.com/google.protobuf.FloatValue":
+			result.Type = "float"
+		case "type.googleapis.com/google.protobuf.DoubleValue":
+			result.Type = "double"
+		case "type.googleapis.com/google.protobuf.BytesValue":
+			result.Type = "bytes"
+		case "type.googleapis.com/google.protobuf.Timestamp":
+			result.Type = "timestamp"
+		case "type.googleapis.com/google.protobuf.Duration":
+			result.Type = "duration"
+		default:
+			result.Type = "unknown"
+		}
+		results = append(results, result)
+	}
+
+	// Sort the result by name so that the output will be predictable:
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Name < results[j].Name
+	})
+
+	return results
 }

--- a/internal/cmd/create/cluster/templates/template_not_found.txt
+++ b/internal/cmd/create/cluster/templates/template_not_found.txt
@@ -1,0 +1,13 @@
+Template '{{ .Template }}' doesn't exist.
+
+The following are some of the valid templates:
+
+{{ range .Templates }}
+- {{ .GetId }}{{ if .GetTitle }} - {{ .GetTitle }}{{ end -}}
+{{ end }}
+
+To see the complete list of templates use the following command:
+
+{{ .Binary }} get clustertemplates
+
+Use the '--help' option to get more details about the command.

--- a/internal/cmd/create/cluster/templates/template_parameter_issues.txt
+++ b/internal/cmd/create/cluster/templates/template_parameter_issues.txt
@@ -1,0 +1,19 @@
+There are issues with the template parameters:
+
+{{ range .Issues }}
+- {{ . -}}
+{{ end }}
+
+{{ if .Parameters }}
+Valid parameters are the following:
+
+{{ range .Parameters }}
+- {{ .Name }} - {{ .Type }}{{ if .Title }} - {{ .Title }}{{ end -}}
+{{ end }}
+
+For more details about the template parameters run this:
+{{ end }}
+
+{{ .Binary }} get clustertemplate {{ .Template }} -o yaml
+
+Use the '--help' option to get more details about the command.

--- a/internal/exit/exit_error.go
+++ b/internal/exit/exit_error.go
@@ -11,31 +11,20 @@ Unless required by applicable law or agreed to in writing, software distributed 
 language governing permissions and limitations under the License.
 */
 
-package main
+package exit
 
-import (
-	"context"
-	"fmt"
-	"os"
+import "fmt"
 
-	"github.com/innabox/fulfillment-cli/internal/cmd"
-	"github.com/innabox/fulfillment-cli/internal/exit"
-)
+// Error is an error type that contains a process exit code. This is itended for situations where/ you want to call
+// os.Exit only in one place, but also want some deeply nested functions to decide what should be the exit code.
+type Error int
 
-func main() {
-	// Create a context:
-	ctx := context.Background()
+// Error is the implementation of the error interface.
+func (e Error) Error() string {
+	return fmt.Sprintf("%d", e)
+}
 
-	// Execute the main command:
-	root := cmd.Root()
-	err := root.ExecuteContext(ctx)
-	if err != nil {
-		exitErr, ok := err.(exit.Error)
-		if ok {
-			os.Exit(exitErr.Code())
-		} else {
-			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-			os.Exit(1)
-		}
-	}
+// Code returns the exit code.
+func (e Error) Code() int {
+	return int(e)
 }


### PR DESCRIPTION
This patch adds the following command line flags to the `create cluster` command:

- `--template-parameter` - Sets a value for a template parameter.
- `--template-parameter-file` - Sets a value for a template parameter reading it from a file.

The flags can be abbreviated as `-p` for values, and `-f` for files.

The values of this flag should have the format `name=value` and `name=file`.

The parameters are validated using the template definition and an error message is displayed if there are issues. For example, if the user tries to use a template that doesn't exist:

```
$ fulfillment-cli create cluster --template junk
Template 'junk' doesn't exist.

The following are some of the valid templates:

- ocp_4_17_small - OpenShift 4.17 small
- ocp_4_18_small - OpenShift 4.18 small

To see the complete list of templates use the following command:

fulfillment-cli get clustertemplates

Use the '--help' option to get more details about the command.
```

Or if the user tries to use incorrect template parameters:

```
$ ./fulfillment-cli create cluster -t ocp_4_17_small -f my_bool=junk -p hi -p =foo -p my_int=bad
There are issues with the template parameters:

- In 'hi' parameter 'hi' doesn't exist, and if it existed the value would be missing
- In '=foo' parameter name is missing
- In 'my_int=bad' value 'bad' isn't a valid 32-bit integer
- In 'my_bool=junk' file 'junk' doesn't exist
- Parameter 'my_string' is required

Valid parameters are the following:

- my_bool - boolean - My flag
- my_int - int32 - My count
- my_string - string

For more details about the template parameters run this:

./fulfillment-cli get clustertemplate ocp_4_17_small -o yaml

Use the '--help' option to get more details about the command.
```