### PR TITLE
Add basic support for the `Host` and `HostPool` types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/cel-go v0.26.1
 	github.com/google/uuid v1.6.0
-	github.com/innabox/fulfillment-common v0.0.1
+	github.com/innabox/fulfillment-common v0.0.2
 	github.com/onsi/ginkgo/v2 v2.25.3
 	github.com/onsi/gomega v1.38.2
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 h1:8Tjv8EJ+pM1xP8mK6egEbD1OgnV
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2/go.mod h1:pkJQ2tZHJ0aFOVEEot6oZmaVEZcRme73eIFmhiVuRWs=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/innabox/fulfillment-common v0.0.1 h1:2ZzmKp4eI2EDSA2naG1pmTwmoWGkoLgIKsUGmIkLE5g=
-github.com/innabox/fulfillment-common v0.0.1/go.mod h1:eHSg3oUpg7uMEOZaw8Ou3uwvtaSEkOcbOhpdB9ujgsw=
+github.com/innabox/fulfillment-common v0.0.2 h1:krpPANgvasf0TK/KFmTmaCBctblJsEwY7ZIQHvqDwiY=
+github.com/innabox/fulfillment-common v0.0.2/go.mod h1:eHSg3oUpg7uMEOZaw8Ou3uwvtaSEkOcbOhpdB9ujgsw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/internal/cmd/get/tables/fulfillment.v1.Host.yaml
+++ b/internal/cmd/get/tables/fulfillment.v1.Host.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: POWER
+  value: this.status.power_state

--- a/internal/cmd/get/tables/fulfillment.v1.HostPool.yaml
+++ b/internal/cmd/get/tables/fulfillment.v1.HostPool.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: STATE
+  value: this.status.state

--- a/internal/cmd/get/tables/private.v1.Host.yaml
+++ b/internal/cmd/get/tables/private.v1.Host.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: POWER
+  value: this.status.power_state

--- a/internal/cmd/get/tables/private.v1.HostPool.yaml
+++ b/internal/cmd/get/tables/private.v1.HostPool.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: STATE
+  value: this.status.state

--- a/internal/reflection/reflection_helper_test.go
+++ b/internal/reflection/reflection_helper_test.go
@@ -131,9 +131,11 @@ var _ = Describe("Reflection helper", func() {
 			Expect(helper.Singulars()).To(ConsistOf(
 				"cluster",
 				"clustertemplate",
+				"host",
 				"hostclass",
-				"virtualmachinetemplate",
+				"hostpool",
 				"virtualmachine",
+				"virtualmachinetemplate",
 			))
 		})
 
@@ -142,8 +144,10 @@ var _ = Describe("Reflection helper", func() {
 				"clusters",
 				"clustertemplates",
 				"hostclasses",
-				"virtualmachinetemplates",
+				"hostpools",
+				"hosts",
 				"virtualmachines",
+				"virtualmachinetemplates",
 			))
 		})
 


### PR DESCRIPTION
This patch updates the CLI to use the version of the common package that contains the `Host` and `HostPool` types and services. As a result it will be now possible to create, update retrieve and delete hosts and host pools, for example:

```
$ ./fulfillment-cli get
You must specify the type of object to get.

The following object types are available:

- fulfillment.v1.Cluster
- fulfillment.v1.ClusterTemplate
- fulfillment.v1.Host
- fulfillment.v1.HostClass
- fulfillment.v1.HostPool
- fulfillment.v1.VirtualMachine
- fulfillment.v1.VirtualMachineTemplate

You can use the above fully qualified names, or the short names:

- clusters
- clustertemplates
- hostclasses
- hostpools
- hosts
- virtualmachines
- virtualmachinetemplates

For example, to get the list of clusters:

  ./fulfillment-cli get fulfillment.v1.Cluster

Or:

  ./fulfillment-cli get clusters

Note that the short names may be ambiguous if the same object type exists in different packages. In
that case the one whose fully qualified name appears first in the list will be used.

Use the '--help' option to get more details about the command.
```