### PR TITLE
Display last_restarted_at field in compute instance output

### DIFF
--- a/internal/cmd/describe/computeinstance/describe_computeinstance_cmd.go
+++ b/internal/cmd/describe/computeinstance/describe_computeinstance_cmd.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	ffv1 "github.com/osac-project/fulfillment-common/api/fulfillment/v1"
 	"github.com/spf13/cobra"
@@ -109,13 +110,18 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		template = ci.Spec.Template
 	}
 	state := "-"
+	lastRestartedAt := "-"
 	if ci.Status != nil {
 		state = ci.Status.State.String()
 		state = strings.Replace(state, "COMPUTE_INSTANCE_STATE_", "", -1)
+		if ci.Status.LastRestartedAt != nil {
+			lastRestartedAt = ci.Status.LastRestartedAt.AsTime().Format(time.RFC3339)
+		}
 	}
 	fmt.Fprintf(writer, "ID:\t%s\n", ci.Id)
 	fmt.Fprintf(writer, "Template:\t%s\n", template)
 	fmt.Fprintf(writer, "State:\t%s\n", state)
+	fmt.Fprintf(writer, "Last Restarted At:\t%s\n", lastRestartedAt)
 	writer.Flush()
 
 	return nil


### PR DESCRIPTION
## Summary

Add support for displaying the `last_restarted_at` timestamp in the compute instance describe command output.

This enables users to see when their VM was last restarted via the CLI, completing the visibility of the VM restart feature ([MGMT-22682](https://issues.redhat.com//browse/MGMT-22682)).

## Changes

- Display "Last Restarted At" field in `describe computeinstance` output
- Format timestamp using RFC3339 standard
- Bump fulfillment-common dependency from v0.0.34 to v0.0.35 to access the new API field
- Add time import for RFC3339 formatting

## Example Output

```
ID:                 019c0955-e374-7747-8455-04d3a78af71d
Template:           osac.templates.ocp_virt_vm
State:              READY
Last Restarted At:  2026-01-29T12:14:36Z
```

## Testing

- ✅ Unit tests pass (90/90 specs)
- ✅ Code formatting pass
- ✅ Pre-commit hooks pass
- ✅ Build successful
- ✅ Manually tested against vmaas-dev environment

## Related

- Relates-to: [MGMT-22682](https://issues.redhat.com/browse/MGMT-22682)
- Depends on: fulfillment-common v0.0.35 (includes fulfillment-api v0.0.25)
- Related PRs:
  - fulfillment-service #283 (merged)
  - cloudkit-operator #100

Generated with [Claude Code](https://claude.com/claude-code)