### PR TITLE
MGMT-22638: Update fulfillment-common to v0.0.43

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,3 +63,5 @@ require (
 	golang.org/x/text v0.29.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250908214217-97024824d090 // indirect
 )
+
+replace github.com/osac-project/fulfillment-common => ../fulfillment-common

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/neilotoole/jsoncolor v0.7.1
 	github.com/onsi/ginkgo/v2 v2.25.3
 	github.com/onsi/gomega v1.38.2
-	github.com/osac-project/fulfillment-common v0.0.42
+	github.com/osac-project/fulfillment-common v0.0.43
 	github.com/spf13/cobra v1.10.1
 	google.golang.org/genproto/googleapis/api v0.0.0-20250908214217-97024824d090
 	google.golang.org/grpc v1.75.1
@@ -63,5 +63,3 @@ require (
 	golang.org/x/text v0.29.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250908214217-97024824d090 // indirect
 )
-
-replace github.com/osac-project/fulfillment-common => ../fulfillment-common

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,6 @@ github.com/onsi/ginkgo/v2 v2.25.3 h1:Ty8+Yi/ayDAGtk4XxmmfUy4GabvM+MegeB4cDLRi6nw
 github.com/onsi/ginkgo/v2 v2.25.3/go.mod h1:43uiyQC4Ed2tkOzLsEYm7hnrb7UJTWHYNsuy3bG/snE=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
-github.com/osac-project/fulfillment-common v0.0.42 h1:7BgZdLgNeVnXnNjhxP3kIJ6vg0o9cKJ9YKQlZSqEYXA=
-github.com/osac-project/fulfillment-common v0.0.42/go.mod h1:Z1x2v8diIg1S4laK62UniHTgliPAIWdtBn/HsXYDrzU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/onsi/ginkgo/v2 v2.25.3 h1:Ty8+Yi/ayDAGtk4XxmmfUy4GabvM+MegeB4cDLRi6nw
 github.com/onsi/ginkgo/v2 v2.25.3/go.mod h1:43uiyQC4Ed2tkOzLsEYm7hnrb7UJTWHYNsuy3bG/snE=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
+github.com/osac-project/fulfillment-common v0.0.43 h1:TrLAUAKUSTkJnYkP1yG6f3cbkIJYMMtEmBIbSYa15oY=
+github.com/osac-project/fulfillment-common v0.0.43/go.mod h1:Z1x2v8diIg1S4laK62UniHTgliPAIWdtBn/HsXYDrzU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Summary

Update fulfillment-cli to use the published `fulfillment-common` v0.0.43 module as part of [MGMT-22638](https://issues.redhat.com/browse/MGMT-22638) Phase 3. This commit picks up the new ComputeInstance states and condition types (Starting, Stopping, Stopped, Paused) that were added in fulfillment-common's Phase 3 changes, and drops the local `replace` directive that was used during development.

## Testing

Build passes: `go build ./...`

Unit tests pass: `go run github.com/onsi/ginkgo/v2/ginkgo run -r`


## Related PRs

- fulfillment-api: https://github.com/osac-project/fulfillment-api/pull/66
- fulfillment-service: https://github.com/osac-project/fulfillment-service/pull/313
- fulfillment-common: https://github.com/osac-project/fulfillment-common/pull/65
- osac-operator: https://github.com/osac-project/osac-operator/pull/124

## Ticket

[MGMT-22638](https://issues.redhat.com/browse/MGMT-22638)