### PR TITLE
MGMT-22638 / MGMT-23103: Fix describe computeinstance to accept name or UUID

### DIFF
--- a/internal/cmd/describe/computeinstance/describe_computeinstance_cmd.go
+++ b/internal/cmd/describe/computeinstance/describe_computeinstance_cmd.go
@@ -81,9 +81,21 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	// Create the client for the compute instances service:
 	client := ffv1.NewComputeInstancesClient(conn)
 
-	// Get the compute instance:
+	// Look up the compute instance by ID or name using a CEL filter:
+	filter := fmt.Sprintf("this.id in ['%s'] || this.metadata.name in ['%s']", id, id)
+	listResponse, err := client.List(ctx, ffv1.ComputeInstancesListRequest_builder{
+		Filter: &filter,
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to describe compute instance: %w", err)
+	}
+	if len(listResponse.GetItems()) == 0 {
+		return fmt.Errorf("compute instance not found: %s", id)
+	}
+
+	// Get the full object using the resolved UUID:
 	response, err := client.Get(ctx, ffv1.ComputeInstancesGetRequest_builder{
-		Id: id,
+		Id: listResponse.GetItems()[0].GetId(),
 	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to describe compute instance: %w", err)


### PR DESCRIPTION
## Summary

[MGMT-23103](https://issues.redhat.com/browse/MGMT-23103) added explicit spec fields to `ComputeInstanceSpec`, replacing the old template parameters. While testing [MGMT-22638](https://issues.redhat.com/browse/MGMT-22638) (Phase 3), `describe computeinstance` was found to only accept UUIDs — passing a name returned a not-found error because the command called `Get(id)` directly without name resolution.

This PR fixes the describe command. The `create computeinstance` flag changes are handled separately in [#110](https://github.com/osac-project/fulfillment-cli/pull/110) (already merged).

**Fix:** `describe computeinstance` now accepts a name or UUID. Replaces the direct `Get()` call with a List+Get pattern: a CEL filter resolves the argument to a UUID first, then `Get()` fetches the full object.

## Testing

Tested on `edge-22.edge.lab.eng.rdu2.redhat.com`, namespace `osac-devel`.

```
$ fulfillment-cli describe computeinstance describe-test
ID:        019cb1e2-c76f-7087-8f9c-650a05cc14d1
Template:  osac.templates.ocp_virt_vm
State:     STARTING

$ fulfillment-cli describe computeinstance 019cb1e2-c76f-7087-8f9c-650a05cc14d1
ID:        019cb1e2-c76f-7087-8f9c-650a05cc14d1
Template:  osac.templates.ocp_virt_vm
State:     STARTING

$ fulfillment-cli describe computeinstance does-not-exist
Error: compute instance not found: does-not-exist
```

Name and UUID lookups return identical output. Non-existent instance returns a clean error. UUID regression: clean.

## Pre-merge ToDos

1. Merge fulfillment-common [#66](https://github.com/osac-project/fulfillment-common/pull/66) and tag a new fulfillment-common release — this PR will be updated to bump to that version before merging.

## Related PRs

- fulfillment-common [#66](https://github.com/osac-project/fulfillment-common/pull/66) — private-api v0.0.44 bump (must merge and tag first)
- fulfillment-service [#309](https://github.com/osac-project/fulfillment-service/pull/309) — `addExplicitFields()` mapping (already merged)
- fulfillment-cli [#110](https://github.com/osac-project/fulfillment-cli/pull/110) — `create computeinstance` explicit spec flags (already merged)

## Tickets

- [MGMT-22638](https://issues.redhat.com/browse/MGMT-22638) — Phase 3 testing where the gap was discovered
- [MGMT-23103](https://issues.redhat.com/browse/MGMT-23103) — explicit spec fields that required these CLI changes

<br>
<br>

<sub>Assisted-by: Claude</sub>